### PR TITLE
Fix link

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         </tr>
         <br>
         <ul>
-          <li><a target="_blank" href="https://github.com/interactive-instruments/etf-webapp/releases/latest">Download <strong>ETF</strong></a></li>
+          <li><a target="_blank" href="https://github.com/etf-validator/etf-webapp/releases/latest">Download <strong>ETF</strong></a></li>
           <li><a target="_blank" href="https://hub.docker.com/r/iide/etf-webapp">Install from<strong>DockerHub</strong></a></li>
           <li><a target="_blank" href="http://docs.etf-validator.net">View <strong>Manuals</strong></a></li>
         </ul>
@@ -71,7 +71,7 @@
       <p>The easiest way to deploy ETF is a Docker container, available on <a target="_blank" href="https://hub.docker.com/r/iide/etf-webapp">Docker Hub.</a></p>
 		<p><small>ETF version 1:
 		&copy; 2010-2016 interactive instruments GmbH. Licensed under the Apache 2.0 License.</small></p>
-		<p><small>ETF version 2: 
+		<p><small>ETF version 2:
 		&copy; 2017 European Union, interactive instruments GmbH. Licensed under the EUPL.<br/>
 		This work was supported by the <a href="http://ec.europa.eu/isa">EU Interoperability Solutions for European Public Administrations Programme</a> through <a href="https://joinup.ec.europa.eu/community/are3na/description">Action 1.17: A Reusable INSPIRE Reference Platform (ARE3NA)</a>.</small></p>
       </section>


### PR DESCRIPTION
https://github.com/interactive-instruments/etf-webapp to
https://github.com/etf-validator